### PR TITLE
[#45] 로그인 -> 답변 확인 -> 처음으로 클릭 시 다시 로그인 페이지로 돌아가는 문제 해결

### DIFF
--- a/LuckyVicky/LuckyVicky/Presentation/Coordinator/Coordinator.swift
+++ b/LuckyVicky/LuckyVicky/Presentation/Coordinator/Coordinator.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 protocol Coordinator {
+    func start(with scene: AppScene)
     func push(_ scene: AppScene)
     func pop()
     func popToRoot()

--- a/LuckyVicky/LuckyVicky/Presentation/Coordinator/MainCoordinator.swift
+++ b/LuckyVicky/LuckyVicky/Presentation/Coordinator/MainCoordinator.swift
@@ -11,7 +11,7 @@ final class MainCoordinator: ObservableObject, Coordinator {
     
     @Published var path: NavigationPath
     @Published var sheet: AppScene?
-    private let initialScene: AppScene
+    private var initialScene: AppScene
     var injector: Injector?
     
     init(_ initialScene: AppScene) {
@@ -21,6 +21,12 @@ final class MainCoordinator: ObservableObject, Coordinator {
     
     func buildInitialScene() -> some View {
         return buildScene(scene: initialScene)
+    }
+    
+    func start(with scene: AppScene) {
+        self.path = NavigationPath()
+        self.sheet = nil
+        self.initialScene = scene
     }
     
     func push(_ scene: AppScene) {

--- a/LuckyVicky/LuckyVicky/Presentation/Scenes/Common/ViewModel/LoginViewModel.swift
+++ b/LuckyVicky/LuckyVicky/Presentation/Scenes/Common/ViewModel/LoginViewModel.swift
@@ -61,7 +61,7 @@ extension LoginViewModel {
                     UserDefaults.userId = user.id
                     UserDefaults.usedCount = user.usedCount
                     UserDefaults.isFirstLaunch = false
-                    self?.coordinator.present(sheet: .selectCharacter)
+                    self?.coordinator.start(with: .selectCharacter)
                 }.store(in: &cancellables)
         } else if case .failure(_) = result {
             state.isLoading = false

--- a/LuckyVicky/LuckyVicky/Presentation/Scenes/ConvertThought/ViewModel/SelectCharacterViewModel.swift
+++ b/LuckyVicky/LuckyVicky/Presentation/Scenes/ConvertThought/ViewModel/SelectCharacterViewModel.swift
@@ -88,7 +88,7 @@ extension SelectCharacterViewModel {
                 }
             } receiveValue: { [weak self] _ in
                 UserDefaults.standard.removeAllUserDefaulsKeys()
-                self?.coordinator.present(sheet: .login)
+                self?.coordinator.start(with: .login)
             }.store(in: &cancellables)
     }
     


### PR DESCRIPTION
## What is this PR? 🔍 

<!-- 구현사항을 간단히 설명해주세요. -->
- 루트 뷰가 로그인 뷰일 경우 처음으로 돌아가기 클릭 시 다시 로그인 페이지로 돌아가는 문제를 해결했습니다.

## Changes 📝

<!-- 주요 변경 사항 및 설명 혹은 확인이 필요한 코드에 대한 설명을 함께 기재해주세요. -->
- Coordinator 프로토콜에 `start` 함수 추가 로그인 완료 시 coordinator 새로 시작하도록

## Screenshot 📷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |

## 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #45 
